### PR TITLE
GUNDI-4995: Refactors & quiet period support for bad credentials

### DIFF
--- a/app/actions/client.py
+++ b/app/actions/client.py
@@ -2,42 +2,45 @@ import logging
 import httpx
 import stamina
 
-from datetime import datetime, timezone, timedelta
+from datetime import datetime, timedelta
+
+from app.services.state import IntegrationStateManager
 
 
+state_manager = IntegrationStateManager()
 logger = logging.getLogger(__name__)
 
 REQUESTED_PROPERTIES = 'unit_id,unit_name,organization_name,real_time_GPS_Time,real_time_status,real_time_Latitude,real_time_Longitude,real_time_Distance,real_time_Speed'
 
 
 
-class GalooliGeneralErrorException(Exception):
-    def __init__(self, error: Exception, message: str, code=-1):
+
+class GalooliException(Exception):
+    def __init__(self, message: str, code: int = -1):
         self.code = code
         self.message = message
-        self.error = error
-        super().__init__(f"'{self.code}: {self.message}, Error: {self.error}'")
+        text = f"{self.code}: {self.message}"
+        super().__init__(text)
 
 
-class GalooliInvalidUserCredentialsException(Exception):
-    def __init__(self, error: Exception, message: str, code=1000):
-        self.code = code
-        self.message = message
-        self.error = error
-        super().__init__(f"'{self.code}: {self.message}, Error: {self.error}'")
+class GalooliGeneralErrorException(GalooliException):
+    def __init__(self, message: str, code: int = -1):
+        super().__init__(message, code=code)
 
 
-class GalooliTooManyRequestsException(Exception):
-    def __init__(self, error: Exception, message: str, code=1101):
-        self.code = code
-        self.message = message
-        self.error = error
-        super().__init__(f"'{self.code}: {self.message}, Error: {self.error}'")
+class GalooliInvalidUserCredentialsException(GalooliException):
+    def __init__(self, message: str, code: int = 1000):
+        super().__init__(message, code=code)
 
 
-@stamina.retry(on=GalooliTooManyRequestsException, wait_initial=4.0, wait_jitter=5.0, wait_max=32.0)
-async def get_observations(url, *, username: str, password: str, start: datetime):
-    async with httpx.AsyncClient(timeout=120) as session:
+class GalooliTooManyRequestsException(GalooliException):
+    def __init__(self, message: str, code: int = 1101):
+        super().__init__(message, code=code)
+
+
+@stamina.retry(on=GalooliTooManyRequestsException, attempts=3, wait_initial=4.0, wait_jitter=5.0, wait_max=32.0)
+async def get_observations(url, *, integration_id: str, username: str, password: str, start: datetime):
+    async with httpx.AsyncClient(timeout=httpx.Timeout(connect=10.0, read=30.0, write=15.0, pool=5.0)) as session:
         params = {
             'requestedPropertiesStr': REQUESTED_PROPERTIES,
             'lastGMTUpdateTime': start.strftime("%Y-%m-%d %H:%M:%S"),
@@ -55,28 +58,26 @@ async def get_observations(url, *, username: str, password: str, start: datetime
                 result_code = parsed_response['CommonResult']['ResultCode']
                 if result_code != 0:
                     result_description = parsed_response['CommonResult'].get('ResultDescription', parsed_response['CommonResult'].get('RejectReason'))
-                    if result_code == 1000:
-                        raise GalooliInvalidUserCredentialsException(
-                            Exception(),
-                            result_description
-                        )
                     if result_code == 1101:
-                        raise GalooliTooManyRequestsException(
-                            Exception(),
-                            result_description
+                        raise GalooliTooManyRequestsException(message=result_description)
+                    elif result_code == 1000:
+                        logger.error(f"Galooli returned '{result_code}:{result_description}' error for user {username}. Setting 15 mins of quiet period...")
+                        await state_manager.set_quiet_period(
+                            integration_id=integration_id,
+                            action_id="pull_observations",
+                            quiet_period=timedelta(minutes=15)
                         )
-                    raise GalooliGeneralErrorException(
-                        Exception(),
-                        f"General error occurred. Result code: {result_code}"
-                    )
+                        raise GalooliInvalidUserCredentialsException(message=result_description)
+                    raise GalooliGeneralErrorException(message=f"General error occurred. Result code: {result_code}")
 
                 return parsed_response
             else:
                 logger.info(f"Galooli response: {response.text}")
+                return None
 
         except httpx.HTTPStatusError as e:
             if e.response.status_code == 403:
-                raise GalooliInvalidUserCredentialsException(e, "Unauthorized access", code=403)
+                raise GalooliInvalidUserCredentialsException("Unauthorized access", code=403)
             if e.response.status_code == 404:
-                raise GalooliGeneralErrorException(e, "Not found", code=404)
+                raise GalooliGeneralErrorException("Not found", code=404)
             raise e

--- a/app/actions/client.py
+++ b/app/actions/client.py
@@ -11,6 +11,7 @@ state_manager = IntegrationStateManager()
 logger = logging.getLogger(__name__)
 
 REQUESTED_PROPERTIES = 'unit_id,unit_name,organization_name,real_time_GPS_Time,real_time_status,real_time_Latitude,real_time_Longitude,real_time_Distance,real_time_Speed'
+QUIET_PERIOD_MINS = 15
 
 
 
@@ -61,11 +62,11 @@ async def get_observations(url, *, integration_id: str, username: str, password:
                     if result_code == 1101:
                         raise GalooliTooManyRequestsException(message=result_description)
                     elif result_code == 1000:
-                        logger.error(f"Galooli returned '{result_code}:{result_description}' error for user {username}. Setting 15 mins of quiet period...")
+                        logger.warning(f"Galooli returned '{result_code}:{result_description}' error for user {username}. Setting {QUIET_PERIOD_MINS} mins of quiet period...")
                         await state_manager.set_quiet_period(
                             integration_id=integration_id,
                             action_id="pull_observations",
-                            quiet_period=timedelta(minutes=15)
+                            quiet_period=timedelta(minutes=QUIET_PERIOD_MINS)
                         )
                         raise GalooliInvalidUserCredentialsException(message=result_description)
                     raise GalooliGeneralErrorException(message=f"General error occurred. Result code: {result_code}")
@@ -77,6 +78,12 @@ async def get_observations(url, *, integration_id: str, username: str, password:
 
         except httpx.HTTPStatusError as e:
             if e.response.status_code == 403:
+                logger.warning(f"Galooli returned HTTP 403 error for user {username}. Setting {QUIET_PERIOD_MINS} mins of quiet period...")
+                await state_manager.set_quiet_period(
+                    integration_id=integration_id,
+                    action_id="pull_observations",
+                    quiet_period=timedelta(minutes=QUIET_PERIOD_MINS)
+                )
                 raise GalooliInvalidUserCredentialsException("Unauthorized access", code=403)
             if e.response.status_code == 404:
                 raise GalooliGeneralErrorException("Not found", code=404)

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -1,6 +1,9 @@
 import httpx
 import logging
 import csv
+
+from gundi_core.schemas.v2 import LogLevel
+
 import app.actions.client as client
 from dateparser import parse as dp
 from functional import seq
@@ -10,7 +13,7 @@ import pytz
 from io import StringIO
 from app.actions.configurations import AuthenticateConfig, PullObservationsConfig, get_auth_config
 from app.actions.utils import convert_to_gundi_observation, filter_observations_by_device_status
-from app.services.activity_logger import activity_logger
+from app.services.activity_logger import activity_logger, log_action_activity
 from app.services.action_scheduler import crontab_schedule
 from app.services.gundi import send_observations_to_gundi
 from app.services.state import IntegrationStateManager
@@ -49,6 +52,18 @@ async def action_auth(integration, action_config: AuthenticateConfig):
 @activity_logger()
 async def action_pull_observations(integration, action_config: PullObservationsConfig):
     logger.info(f"Executing 'pull_observations' action with integration ID {integration.id} and action_config {action_config}...")
+    result = {}
+
+    if await state_manager.is_quiet_period(str(integration.id), "pull_observations"):
+        await log_action_activity(
+            integration_id=integration.id,
+            action_id="pull_observations",
+            level=LogLevel.WARNING,
+            title="Quiet period active - skipping observation pull.",
+            data={"message": "A quiet period is currently active due to credentials issues."}
+        )
+        result["message"] = "Quiet period is active."
+        return result
 
     url = integration.base_url or GALOOLI_BASE_URL
     auth_config = get_auth_config(integration)
@@ -72,6 +87,7 @@ async def action_pull_observations(integration, action_config: PullObservationsC
         
         if get_observations_response := await client.get_observations(
             url,
+            integration_id=str(integration.id),
             username=auth_config.username,
             password=auth_config.password.get_secret_value(),
             start=start
@@ -103,24 +119,26 @@ async def action_pull_observations(integration, action_config: PullObservationsC
                     response = await send_observations_to_gundi(observations=batch, integration_id=integration.id)
                     observations_extracted += len(response)
 
+                # Save latest execution time to state
+                latest_time = get_observations_response["MaxGmtUpdateTime"]
+                state = {"last_updated_time": latest_time}
+
+                await state_manager.set_state(
+                    integration_id=integration.id,
+                    action_id="pull_observations",
+                    state=state
+                )
+                logger.info(f"State updated for integration {integration.id} with last_updated_time: {latest_time}")
+
             else:
                 logger.warning(f"No valid observations found for Username: {auth_config.username}")
 
-            # Save latest execution time to state
-            latest_time = get_observations_response["MaxGmtUpdateTime"]
-            state = {"last_updated_time": latest_time}
-
-            await state_manager.set_state(
-                integration_id=integration.id,
-                action_id="pull_observations",
-                state=state
-            )
-            logger.info(f"State updated for integration {integration.id} with last_updated_time: {latest_time}")
-
-            return {"observations_extracted": observations_extracted}
+            result["observations_extracted"] = observations_extracted
+            return result
         else:
             logger.warning(f"No observations found for Username: {auth_config.username}")
-            return {"observations_extracted": 0}
+            result["observations_extracted"] = 0
+            return result
     except (client.GalooliInvalidUserCredentialsException, client.GalooliGeneralErrorException, client.GalooliTooManyRequestsException) as e:
         logger.error(f"Galooli API returned error for integration {integration.id}. Exception: {e}")
         raise

--- a/app/actions/tests/test_client.py
+++ b/app/actions/tests/test_client.py
@@ -153,12 +153,15 @@ class TestGetObservations:
             assert "General error occurred" in str(exc_info.value)
 
     @pytest.mark.asyncio
-    async def test_get_observations_http_error_403(self, mock_request_params):
+    async def test_get_observations_http_error_403_sets_quiet_period(self, mock_request_params):
         """Test observation retrieval with HTTP 403 error"""
         mock_response = MagicMock()
         mock_response.status_code = 403
-        
-        with patch('httpx.AsyncClient') as mock_client_class:
+
+        with (
+            patch("app.actions.client.httpx.AsyncClient") as mock_client_class,
+            patch("app.actions.client.state_manager.set_quiet_period", new_callable=AsyncMock) as mock_set_quiet
+        ):
             mock_client = AsyncMock()
             mock_client_class.return_value.__aenter__.return_value = mock_client
             mock_client.get.side_effect = httpx.HTTPStatusError(
@@ -169,6 +172,12 @@ class TestGetObservations:
                 await get_observations(**mock_request_params)
             
             assert exc_info.value.code == 403
+
+            mock_set_quiet.assert_awaited_once_with(
+                integration_id="test_integration",
+                action_id="pull_observations",
+                quiet_period=timedelta(minutes=15),
+            )
 
     @pytest.mark.asyncio
     async def test_get_observations_http_error_404(self, mock_request_params):

--- a/app/actions/tests/test_client.py
+++ b/app/actions/tests/test_client.py
@@ -19,6 +19,7 @@ class TestGetObservations:
         """Mock request parameters for get_observations"""
         return {
             'url': "https://test.galooli.com/api",
+            'integration_id': "test_integration",
             'username': "test_user",
             'password': "test_password",
             'start': datetime(2024, 6, 27, 12, 0, 0, tzinfo=timezone.utc)
@@ -74,7 +75,7 @@ class TestGetObservations:
             assert call_args[1]['params']['password'] == "test_password"
 
     @pytest.mark.asyncio
-    async def test_get_observations_invalid_credentials(self, mock_request_params):
+    async def test_get_observations_invalid_credentials_sets_quiet_period(self, mock_request_params):
         """Test observation retrieval with invalid credentials"""
         mock_response = MagicMock()
         mock_response.is_error = False
@@ -84,8 +85,11 @@ class TestGetObservations:
                 'ResultDescription': 'Invalid credentials'
             }
         }
-        
-        with patch('httpx.AsyncClient') as mock_client_class:
+
+        with (
+            patch("app.actions.client.httpx.AsyncClient") as mock_client_class,
+            patch("app.actions.client.state_manager.set_quiet_period", new_callable=AsyncMock) as mock_set_quiet
+        ):
             mock_client = AsyncMock()
             mock_client_class.return_value.__aenter__.return_value = mock_client
             mock_client.get.return_value = mock_response
@@ -95,6 +99,12 @@ class TestGetObservations:
             
             assert exc_info.value.code == 1000
             assert "Invalid credentials" in str(exc_info.value)
+
+            mock_set_quiet.assert_awaited_once_with(
+                integration_id="test_integration",
+                action_id="pull_observations",
+                quiet_period=timedelta(minutes=15),
+            )
 
     @pytest.mark.asyncio
     async def test_get_observations_too_many_requests(self, mock_request_params):

--- a/app/actions/tests/test_handlers.py
+++ b/app/actions/tests/test_handlers.py
@@ -64,7 +64,7 @@ class TestActionAuth:
         """Test authentication with invalid credentials"""
         with patch('app.actions.handlers.client.get_observations') as mock_get_obs:
             mock_get_obs.side_effect = GalooliInvalidUserCredentialsException(
-                Exception(), "Invalid credentials", 1000
+                "Invalid credentials", 1000
             )
             
             result = await action_auth(mock_integration, mock_action_config)
@@ -80,7 +80,7 @@ class TestActionAuth:
         """Test authentication with general error"""
         with patch('app.actions.handlers.client.get_observations') as mock_get_obs:
             mock_get_obs.side_effect = GalooliGeneralErrorException(
-                Exception(), "General error", -1
+                "General error", -1
             )
             
             result = await action_auth(mock_integration, mock_action_config)
@@ -96,7 +96,7 @@ class TestActionAuth:
         """Test authentication with too many requests error"""
         with patch('app.actions.handlers.client.get_observations') as mock_get_obs:
             mock_get_obs.side_effect = GalooliTooManyRequestsException(
-                Exception(), "Too many requests", 1101
+                "Too many requests", 1101
             )
             
             result = await action_auth(mock_integration, mock_action_config)
@@ -204,6 +204,7 @@ class TestActionPullObservations:
              patch('app.actions.handlers.state_manager.get_state', return_value={}), \
              patch('app.actions.utils.state_manager.set_state', return_value={}), \
              patch('app.actions.utils.state_manager.get_state', return_value={}), \
+             patch('app.actions.handlers.state_manager.is_quiet_period', return_value={}), \
              patch('app.actions.handlers.send_observations_to_gundi', return_value=["obs1", "obs2"]) as mock_send:
             
             result = await action_pull_observations(mock_integration, mock_action_config)
@@ -217,6 +218,7 @@ class TestActionPullObservations:
         with patch('app.actions.handlers.get_auth_config', return_value=mock_auth_config), \
              patch('app.actions.handlers.client.get_observations', return_value=mock_empty_dataset_response), \
              patch('app.actions.handlers.state_manager.set_state', return_value={}), \
+             patch('app.actions.handlers.state_manager.is_quiet_period', return_value={}), \
              patch('app.actions.handlers.state_manager.get_state', return_value={}):
             
             result = await action_pull_observations(mock_integration, mock_action_config)
@@ -229,6 +231,7 @@ class TestActionPullObservations:
         with patch('app.actions.handlers.get_auth_config', return_value=mock_auth_config), \
              patch('app.actions.handlers.client.get_observations', return_value=mock_dataset_bad_observation_response), \
              patch('app.actions.handlers.state_manager.set_state', return_value={}), \
+             patch('app.actions.handlers.state_manager.is_quiet_period', return_value={}), \
              patch('app.actions.handlers.state_manager.get_state', return_value={}):
             
             result = await action_pull_observations(mock_integration, mock_action_config)
@@ -246,6 +249,7 @@ class TestActionPullObservations:
              patch('app.actions.handlers.state_manager.set_state', return_value={}), \
              patch('app.actions.utils.state_manager.set_state', return_value={}), \
              patch('app.actions.utils.state_manager.get_state', return_value={}), \
+             patch('app.actions.handlers.state_manager.is_quiet_period', return_value={}), \
              patch('app.actions.handlers.send_observations_to_gundi', return_value=["obs1", "obs2"]) as mock_send:
             
             result = await action_pull_observations(mock_integration, mock_action_config)
@@ -253,6 +257,7 @@ class TestActionPullObservations:
             assert result == {"observations_extracted": 2}
             mock_get_obs.assert_called_once_with(
                 "https://custom.galooli.com/api",
+                integration_id="test-integration-id",
                 username="test_user",
                 password="test_password",
                 start=mock_get_obs.call_args[1]["start"]
@@ -264,9 +269,10 @@ class TestActionPullObservations:
         """Test pull observations with client exception"""
         with patch('app.actions.handlers.get_auth_config', return_value=mock_auth_config), \
              patch('app.actions.handlers.state_manager.get_state', return_value={}), \
+             patch('app.actions.handlers.state_manager.is_quiet_period', return_value={}), \
              patch('app.actions.handlers.client.get_observations') as mock_get_obs:
             mock_get_obs.side_effect = GalooliInvalidUserCredentialsException(
-                Exception(), "Invalid credentials", 1000
+                "Invalid credentials", 1000
             )
             
             with pytest.raises(GalooliInvalidUserCredentialsException):
@@ -277,6 +283,7 @@ class TestActionPullObservations:
         """Test pull observations with HTTP error"""
         with patch('app.actions.handlers.get_auth_config', return_value=mock_auth_config), \
              patch('app.actions.handlers.state_manager.get_state', return_value={}), \
+             patch('app.actions.handlers.state_manager.is_quiet_period', return_value={}), \
              patch('app.actions.handlers.client.get_observations') as mock_get_obs:
             mock_response = MagicMock()
             mock_response.status_code = 500
@@ -286,6 +293,16 @@ class TestActionPullObservations:
             
             with pytest.raises(httpx.HTTPStatusError):
                 await action_pull_observations(mock_integration, mock_action_config)
+
+    @pytest.mark.asyncio
+    async def test_action_pull_observations_quiet_period_active(self, mock_integration, mock_action_config):
+        """When quiet period is active, ensure log_action_activity is called and proper message is returned"""
+        with patch('app.actions.handlers.state_manager.is_quiet_period', return_value=True), \
+                patch('app.actions.handlers.log_action_activity', new_callable=AsyncMock) as mock_log:
+            result = await action_pull_observations(mock_integration, mock_action_config)
+
+            mock_log.assert_awaited_once()
+            assert result == {"message": "Quiet period is active."}
 
     @pytest.mark.asyncio
     async def test_action_pull_observations_batch_processing(self, mock_integration, mock_action_config, mock_auth_config):
@@ -309,6 +326,7 @@ class TestActionPullObservations:
              patch('app.actions.handlers.state_manager.set_state', return_value={}), \
              patch('app.actions.utils.state_manager.set_state', return_value={}), \
              patch('app.actions.utils.state_manager.get_state', return_value={}), \
+             patch('app.actions.handlers.state_manager.is_quiet_period', return_value={}), \
              patch('app.actions.handlers.send_observations_to_gundi', return_value=["obs"] * 200) as mock_send:
             
             result = await action_pull_observations(mock_integration, mock_action_config)
@@ -373,6 +391,7 @@ class TestHandlersIntegration:
              patch('app.actions.handlers.state_manager.set_state', return_value={}), \
              patch('app.actions.utils.state_manager.set_state', return_value={}), \
              patch('app.actions.utils.state_manager.get_state', return_value={}), \
+            patch('app.actions.handlers.state_manager.is_quiet_period', return_value={}), \
              patch('app.actions.handlers.send_observations_to_gundi', return_value=["obs1"]):
             
             await action_pull_observations(mock_integration, mock_action_config)

--- a/app/services/state.py
+++ b/app/services/state.py
@@ -36,7 +36,7 @@ class IntegrationStateManager:
                     f"integration_state.{integration_id}.{action_id}.{source_id}"
                 )
 
-    async def set_quiet_period(self, integration_id: str, action_id:str, quiet_period: int):
+    async def set_quiet_period(self, integration_id: str, action_id: str, quiet_period: int):
         for attempt in stamina.retry_context(on=redis.RedisError, attempts=5, wait_initial=1.0, wait_max=30, wait_jitter=3.0):
             with attempt:
                 await self.db_client.setex(

--- a/app/services/state.py
+++ b/app/services/state.py
@@ -36,6 +36,20 @@ class IntegrationStateManager:
                     f"integration_state.{integration_id}.{action_id}.{source_id}"
                 )
 
+    async def set_quiet_period(self, integration_id: str, action_id:str, quiet_period: int):
+        for attempt in stamina.retry_context(on=redis.RedisError, attempts=5, wait_initial=1.0, wait_max=30, wait_jitter=3.0):
+            with attempt:
+                await self.db_client.setex(
+                    f"integration_state.{integration_id}.{action_id}.quiet_period", quiet_period, 1)
+
+    async def is_quiet_period(self, integration_id: str, action_id: str):
+        for attempt in stamina.retry_context(on=redis.RedisError, attempts=5, wait_initial=1.0, wait_max=30, wait_jitter=3.0):
+            with attempt:
+                val = await self.db_client.exists(
+                    f"integration_state.{integration_id}.{action_id}.quiet_period",
+                )
+                return val
+
     def __str__(self):
         return f"IntegrationStateManager(host={self.db_client.host}, port={self.db_client.port}, db={self.db_client.db})"
 

--- a/app/services/state.py
+++ b/app/services/state.py
@@ -48,7 +48,7 @@ class IntegrationStateManager:
                 val = await self.db_client.exists(
                     f"integration_state.{integration_id}.{action_id}.quiet_period",
                 )
-                return val
+        return val
 
     def __str__(self):
         return f"IntegrationStateManager(host={self.db_client.host}, port={self.db_client.port}, db={self.db_client.db})"


### PR DESCRIPTION
### Related Link

https://allenai.atlassian.net/browse/GUNDI-4995

---

This pull request introduces improvements to error handling, state management, and test coverage for the Galooli integration, particularly around handling invalid credentials and quiet periods. 

The changes refactor exception classes for clarity, ensure a quiet period is set and respected after authentication failures, and update tests to cover these behaviors.

**Error handling and state management improvements:**

* Refactored Galooli exception classes to use a clearer inheritance hierarchy, removing redundant parameters and simplifying initialization. (`app/actions/client.py` [app/actions/client.pyL5-R43](diffhunk://#diff-2ec2ed70abf8182f30b27698f142fa49dc3f1539f86eb84d0e5826523cb83013L5-R43))
* When invalid credentials are detected (result code 1000), the system now sets a 15-minute quiet period for the integration and logs a warning, preventing repeated failed attempts and reducing noise. (`app/actions/client.py` [app/actions/client.pyL58-R82](diffhunk://#diff-2ec2ed70abf8182f30b27698f142fa49dc3f1539f86eb84d0e5826523cb83013L58-R82))
* The `get_observations` function now requires an `integration_id` parameter and uses more granular HTTPX timeouts for better reliability. (`app/actions/client.py` [[1]](diffhunk://#diff-2ec2ed70abf8182f30b27698f142fa49dc3f1539f86eb84d0e5826523cb83013L5-R43) [[2]](diffhunk://#diff-2ec2ed70abf8182f30b27698f142fa49dc3f1539f86eb84d0e5826523cb83013L58-R82)

**Observation pull action enhancements:**

* Before pulling observations, the handler checks if a quiet period is active; if so, it logs the event and skips the action, returning an appropriate message. (`app/actions/handlers.py` [app/actions/handlers.pyR55-R66](diffhunk://#diff-f575ea29ea1c9649ccb87f9c38a0fd9a78b9f210c9e5e9d800e328ee30d08113R55-R66))
* Updated the handler to pass `integration_id` to `get_observations` and improved result structure for clarity. (`app/actions/handlers.py` [[1]](diffhunk://#diff-f575ea29ea1c9649ccb87f9c38a0fd9a78b9f210c9e5e9d800e328ee30d08113R90) [[2]](diffhunk://#diff-f575ea29ea1c9649ccb87f9c38a0fd9a78b9f210c9e5e9d800e328ee30d08113L120-R141)

**Test suite updates:**

* Tests now mock and assert the quiet period logic, including verifying that the quiet period is set when invalid credentials are encountered and that the action is skipped when the quiet period is active. (`app/actions/tests/test_client.py` [[1]](diffhunk://#diff-74f0705ca44be1b9b6b7232aff0cc852e26b2e791017adc9c9c4a52a4277b026L88-R92) [[2]](diffhunk://#diff-74f0705ca44be1b9b6b7232aff0cc852e26b2e791017adc9c9c4a52a4277b026R103-R108); `app/actions/tests/test_handlers.py` [[3]](diffhunk://#diff-1d3087a4c8f5f87d441341225d93eba5a73d22523ef90b8f1903714bc31eb11fR207) [[4]](diffhunk://#diff-1d3087a4c8f5f87d441341225d93eba5a73d22523ef90b8f1903714bc31eb11fR221) [[5]](diffhunk://#diff-1d3087a4c8f5f87d441341225d93eba5a73d22523ef90b8f1903714bc31eb11fR234) [[6]](diffhunk://#diff-1d3087a4c8f5f87d441341225d93eba5a73d22523ef90b8f1903714bc31eb11fR252-R260) [[7]](diffhunk://#diff-1d3087a4c8f5f87d441341225d93eba5a73d22523ef90b8f1903714bc31eb11fR272-R275) [[8]](diffhunk://#diff-1d3087a4c8f5f87d441341225d93eba5a73d22523ef90b8f1903714bc31eb11fR286) [[9]](diffhunk://#diff-1d3087a4c8f5f87d441341225d93eba5a73d22523ef90b8f1903714bc31eb11fR297-R306)
* Updated tests to reflect the new exception signatures and to ensure that all relevant branches (invalid credentials, general errors, too many requests, quiet period active) are covered. (`app/actions/tests/test_handlers.py` [[1]](diffhunk://#diff-1d3087a4c8f5f87d441341225d93eba5a73d22523ef90b8f1903714bc31eb11fL67-R67) [[2]](diffhunk://#diff-1d3087a4c8f5f87d441341225d93eba5a73d22523ef90b8f1903714bc31eb11fL83-R83) [[3]](diffhunk://#diff-1d3087a4c8f5f87d441341225d93eba5a73d22523ef90b8f1903714bc31eb11fL99-R99)

These changes collectively make the integration more robust against repeated authentication failures, provide clearer logging and error handling, and ensure that the system's state is managed consistently during error scenarios.

### Tests

This feature has been tested in local executions and with unit testing.
